### PR TITLE
Restore spaces collapsed by the Astro 7 compiler

### DIFF
--- a/src/pages/articles.astro
+++ b/src/pages/articles.astro
@@ -23,7 +23,7 @@ function getArticleUrl(article: CollectionEntry<'articles'>) {
     articles.map(article => (
       <>
         <h2>
-          <a href={getArticleUrl(article)}>{article.data.title}</a>
+          <a href={getArticleUrl(article)}>{article.data.title}</a>{' '}
           <time class="text-gray-500" datetime={article.data.date.toISOString()}>
             {article.data.date.toLocaleDateString('en-US', {
               year: 'numeric',
@@ -33,7 +33,7 @@ function getArticleUrl(article: CollectionEntry<'articles'>) {
           </time>
         </h2>
         <p>
-          <span set:text={article.data.description} />
+          <span set:text={article.data.description} />{' '}
           <a href={getArticleUrl(article)} class="no-underline">
             →
           </a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -195,13 +195,13 @@ const criticalStyle = String.raw`<style>
         <div class="home-copy">
           <img src="/cottongeeks.svg" alt="Cottongeeks LLC" class="home-logo" />
           <p>
-            Cottongeeks is a solo-powered boutique consultancy led by
+            Cottongeeks is a solo-powered boutique consultancy led by{' '}
             <a href="https://www.linkedin.com/in/debugjois">Deepak Jois</a>, a software engineer
             with over 20 years of industry experience. We partner with startup founders and
             early-stage tech businesses to transform their ideas into production-ready solutions.
           </p>
           <p>
-            Check out some <a href="/articles">articles</a>, or email us at
+            Check out some <a href="/articles">articles</a>, or email us at{' '}
             <a href="mailto:hi@cottongeeks.com">hi@cottongeeks.com</a>
           </p>
         </div>


### PR DESCRIPTION
Astro 7's compiler follows JSX whitespace rules, so a newline between text and an inline element on the next line no longer renders as a space. Add explicit {' '} at the affected break points on the home and articles pages:

- index: "led by <Deepak Jois>" and "email us at <hi@cottongeeks.com>"
- articles: title/date in each <h2> and description/arrow in each <p>


Claude-Session: https://claude.ai/code/session_0138isfczu8hyiPTjiM5SgoF